### PR TITLE
fix: add newlines if they are missing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export function getPrivateKey(options: Options = {}): string | null {
 function addNewlines(privateKey: string): string {
   const middleLength = privateKey.length - begin.length - end.length - 2;
   const middle = privateKey.substr(begin.length + 1, middleLength);
-  return `${begin}\n${middle.replace(/\s+/g, "\n")}\n${end}`;
+  return `${begin}\n${middle.trim().replace(/\s+/g, "\n")}\n${end}`;
 }
 
 getPrivateKey.VERSION = VERSION;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export function getPrivateKey(options: Options = {}): string | null {
 function addNewlines(privateKey: string): string {
   const middleLength = privateKey.length - begin.length - end.length - 2;
   const middle = privateKey.substr(begin.length + 1, middleLength);
-  return `${begin}\n${middle.replace(/\s/g, "\n")}\n${end}`;
+  return `${begin}\n${middle.replace(/\s+/g, "\n")}\n${end}`;
 }
 
 getPrivateKey.VERSION = VERSION;

--- a/test/get-private-key.test.ts
+++ b/test/get-private-key.test.ts
@@ -10,7 +10,13 @@ const readdirSync = fs.readdirSync as jest.Mock;
 const readFileSync = fs.readFileSync as jest.Mock;
 
 const PRIVATE_KEY =
-  "-----BEGIN RSA PRIVATE KEY-----\n ... \n-----END RSA PRIVATE KEY-----";
+  "-----BEGIN RSA PRIVATE KEY-----\n7HjkPK\nKLm395\nAIBII\n-----END RSA PRIVATE KEY-----";
+
+const PRIVATE_KEY_NO_NEWLINES =
+  "-----BEGIN RSA PRIVATE KEY----- 7HjkPK KLm395 AIBII -----END RSA PRIVATE KEY-----";
+
+const PRIVATE_KEY_ESCAPED_NEWLINES =
+  "-----BEGIN RSA PRIVATE KEY-----\\n7HjkPK\\nKLm395\\nAIBII\\n-----END RSA PRIVATE KEY-----";
 
 describe("getPrivateKey", () => {
   beforeEach(() => {
@@ -119,6 +125,18 @@ describe("getPrivateKey", () => {
       process.env.PRIVATE_KEY = Buffer.from(PRIVATE_KEY, "utf-8").toString(
         "base64"
       );
+      const result = getPrivateKey();
+      expect(result).toEqual(PRIVATE_KEY);
+    });
+
+    it("PRIVATE_KEY contains no newlines", () => {
+      process.env.PRIVATE_KEY = PRIVATE_KEY_NO_NEWLINES;
+      const result = getPrivateKey();
+      expect(result).toEqual(PRIVATE_KEY);
+    });
+
+    it("PRIVATE_KEY contains escaped newlines", () => {
+      process.env.PRIVATE_KEY = PRIVATE_KEY_ESCAPED_NEWLINES;
       const result = getPrivateKey();
       expect(result).toEqual(PRIVATE_KEY);
     });

--- a/test/get-private-key.test.ts
+++ b/test/get-private-key.test.ts
@@ -15,6 +15,9 @@ const PRIVATE_KEY =
 const PRIVATE_KEY_NO_NEWLINES =
   "-----BEGIN RSA PRIVATE KEY----- 7HjkPK KLm395 AIBII -----END RSA PRIVATE KEY-----";
 
+const PRIVATE_KEY_NO_NEWLINES_MULTIPLE_SPACES =
+  "-----BEGIN RSA PRIVATE KEY----- 7HjkPK  KLm395 AIBII   -----END RSA PRIVATE KEY-----";
+
 const PRIVATE_KEY_ESCAPED_NEWLINES =
   "-----BEGIN RSA PRIVATE KEY-----\\n7HjkPK\\nKLm395\\nAIBII\\n-----END RSA PRIVATE KEY-----";
 
@@ -131,6 +134,12 @@ describe("getPrivateKey", () => {
 
     it("PRIVATE_KEY contains no newlines", () => {
       process.env.PRIVATE_KEY = PRIVATE_KEY_NO_NEWLINES;
+      const result = getPrivateKey();
+      expect(result).toEqual(PRIVATE_KEY);
+    });
+
+    it("PRIVATE_KEY contains consecutive spaces", () => {
+      process.env.PRIVATE_KEY = PRIVATE_KEY_NO_NEWLINES_MULTIPLE_SPACES;
       const result = getPrivateKey();
       expect(result).toEqual(PRIVATE_KEY);
     });


### PR DESCRIPTION
when a private key is copied manually into the env variables on github, newlines might get missing altogether. this can lead to issues like https://github.com/auth0/node-jsonwebtoken/issues/642

this change transparently adds newlines if they are missing