### PR TITLE
build: Drop web builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "semantic-release-plugin-update-version-in-files",
         {
           "files": [
-            "pkg/dist-web/*",
             "pkg/dist-node/*",
             "pkg/*/version.*"
           ]

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -45,7 +45,7 @@ async function main() {
       bundle: true,
       platform: "node",
       target: "node18",
-      format: "cjs",
+      format: "esm",
       ...sharedOptions,
     });
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -39,27 +39,15 @@ async function main() {
 
   const entryPoints = ["./pkg/dist-src/index.js"];
 
-  await Promise.all([
-    // Build the a CJS Node.js bundle
-    esbuild.build({
+  await esbuild.build({
       entryPoints,
       outdir: "pkg/dist-node",
       bundle: true,
       platform: "node",
-      target: "node14",
+      target: "node18",
       format: "cjs",
       ...sharedOptions,
-    }),
-    // Build an ESM browser bundle
-    esbuild.build({
-      entryPoints,
-      outdir: "pkg/dist-web",
-      bundle: true,
-      platform: "browser",
-      format: "esm",
-      ...sharedOptions,
-    }),
-  ]);
+    });
 
   // Copy the README, LICENSE to the pkg folder
   await copyFile("LICENSE", "pkg/LICENSE");
@@ -79,7 +67,6 @@ async function main() {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
         main: "dist-node/index.js",
-        module: "dist-web/index.js",
         types: "dist-types/index.d.ts",
         source: "dist-src/index.js",
         sideEffects: false,


### PR DESCRIPTION
This package does not make sense in a browser because it depends on "fs".

Now, there apparently has been a new release, so this is technically a breaking change, but the browser build was never working.